### PR TITLE
Use PlatformTarget=AnyCpu for .net8, x64 for net48.

### DIFF
--- a/ServiceFabric.Mocks.sln
+++ b/ServiceFabric.Mocks.sln
@@ -22,18 +22,18 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ServiceFabric.Mocks.NetCore
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|x64 = Debug|x64
-		Release|x64 = Release|x64
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{2832EB4C-6B37-4CEA-9F8B-7896757E69A7}.Debug|x64.ActiveCfg = Debug|x64
-		{2832EB4C-6B37-4CEA-9F8B-7896757E69A7}.Debug|x64.Build.0 = Debug|x64
-		{2832EB4C-6B37-4CEA-9F8B-7896757E69A7}.Release|x64.ActiveCfg = Release|x64
-		{2832EB4C-6B37-4CEA-9F8B-7896757E69A7}.Release|x64.Build.0 = Release|x64
-		{8409D69F-8033-400D-9956-75A7467B3716}.Debug|x64.ActiveCfg = Debug|x64
-		{8409D69F-8033-400D-9956-75A7467B3716}.Debug|x64.Build.0 = Debug|x64
-		{8409D69F-8033-400D-9956-75A7467B3716}.Release|x64.ActiveCfg = Release|x64
-		{8409D69F-8033-400D-9956-75A7467B3716}.Release|x64.Build.0 = Release|x64
+		{2832EB4C-6B37-4CEA-9F8B-7896757E69A7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2832EB4C-6B37-4CEA-9F8B-7896757E69A7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2832EB4C-6B37-4CEA-9F8B-7896757E69A7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2832EB4C-6B37-4CEA-9F8B-7896757E69A7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8409D69F-8033-400D-9956-75A7467B3716}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8409D69F-8033-400D-9956-75A7467B3716}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8409D69F-8033-400D-9956-75A7467B3716}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8409D69F-8033-400D-9956-75A7467B3716}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/ServiceFabric.Mocks/ServiceFabric.Mocks.csproj
+++ b/src/ServiceFabric.Mocks/ServiceFabric.Mocks.csproj
@@ -7,7 +7,6 @@
     <Version>7.1.0</Version>
     <Authors>Loek Duys</Authors>
     <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
-    <PlatformTarget>x64</PlatformTarget>
     <AssemblyName>ServiceFabric.Mocks</AssemblyName>
     <PackageId>ServiceFabric.Mocks</PackageId>
     <PackageTags>ServiceFabric;Service;Fabric;Actor;Mock;Unit;Test</PackageTags>
@@ -21,7 +20,15 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <IncludeSymbols>true</IncludeSymbols>
-    <Platforms>x64</Platforms>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net48'">
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <Platforms>AnyCPU</Platforms>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release'">

--- a/test/ServiceFabric.Mocks.NetCoreTests/ServiceFabric.Mocks.NetCoreTests.csproj
+++ b/test/ServiceFabric.Mocks.NetCoreTests/ServiceFabric.Mocks.NetCoreTests.csproj
@@ -7,7 +7,7 @@
     <VersionPrefix>1.0.0</VersionPrefix>
     <Authors>Loek Duys</Authors>
     <TargetFramework>net8.0</TargetFramework>
-    <PlatformTarget>x64</PlatformTarget>
+    <PlatformTarget>AnyCPU</PlatformTarget>
     <AssemblyName>ServiceFabric.Mocks.Tests</AssemblyName>
     <PackageId>ServiceFabric.Mocks.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -20,12 +20,11 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Platforms>x64</Platforms>
+    <Platforms>AnyCPU</Platforms>
     <ApplicationIcon />
     <OutputTypeEx>Exe</OutputTypeEx>
     <StartupObject />
     <OutputType>Library</OutputType>
-    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Compile ServiceFabric.Mocks with 
 - AnyCpu target platform for netstandard2.0 
 - x64 target platform for net48 (contains x64 dependency Microsoft.ServiceFabric.Diagnostics)